### PR TITLE
Add temporary party type

### DIFF
--- a/uchsquad/blueprints/characters.py
+++ b/uchsquad/blueprints/characters.py
@@ -29,6 +29,7 @@ def show_characters():
         'temple': (0, 0, 0),
         'azure' : (0, 0, 0),
         'venus' : (0, 0, 0),
+        'tmp'   : (0, 0, 0),
     }
 
     if user_idx:
@@ -71,10 +72,10 @@ def show_characters():
         characters = [dict(r) for r in conn.execute(
             '''
             SELECT
-              idx, server, key, chara_name, job, fame, 
+              idx, server, key, chara_name, job, fame,
               score,
               NULL           AS last_score,   -- placeholder
-              isbuffer, nightmare, temple, azure, venus, use_yn,
+              isbuffer, nightmare, temple, azure, venus, tmp, use_yn,
               display_order
             FROM user_character
             WHERE adventure = ?
@@ -115,9 +116,9 @@ def show_characters():
     
     
         # 4) use_yn=1 캐릭터만 골라서 D/B 집계
-        counts = {cat: {'D': 0, 'B': 0} for cat in ('temple','azure','venus')}
+        counts = {cat: {'D': 0, 'B': 0} for cat in ('temple','azure','venus','tmp')}
         for r in conn.execute(
-            'SELECT isbuffer, temple, azure, venus '
+            'SELECT isbuffer, temple, azure, venus, tmp '
             '  FROM user_character '
             ' WHERE adventure = ? AND use_yn = 1',
             (selected_user['adventure'],)
@@ -220,6 +221,7 @@ def update_flags():
         temple    = 1 if request.form.get(f'temple_{idx}')     else 0
         azure     = 1 if request.form.get(f'azure_{idx}')      else 0
         venus     = 1 if request.form.get(f'venus_{idx}')      else 0
+        tmp       = 1 if request.form.get(f'tmp_{idx}')        else 0
         use_yn    = 1 if request.form.get(f'use_yn_{idx}')     else 0
 
         conn.execute(
@@ -229,10 +231,11 @@ def update_flags():
                    temple    = ?,
                    azure     = ?,
                    venus     = ?,
+                   tmp       = ?,
                    use_yn    = ?
              WHERE idx = ?
             ''',
-            (nightmare, temple, azure, venus, use_yn, idx)
+            (nightmare, temple, azure, venus, tmp, use_yn, idx)
         )
 
     conn.commit()

--- a/uchsquad/blueprints/party.py
+++ b/uchsquad/blueprints/party.py
@@ -179,10 +179,10 @@ def list_and_generate():
     
     
     # ── 각 던전별 전체 캐릭터 / 딜러(D) / 버퍼(B) 집계 ──
-    counts = {cat: {'D': 0, 'B': 0} for cat in ('temple','azure','venus')}
+    counts = {cat: {'D': 0, 'B': 0} for cat in ('temple','azure','venus','tmp')}
     # use_yn=1 캐릭터만
     rows = conn.execute(
-        "SELECT isbuffer, temple, azure, venus FROM user_character WHERE use_yn=1"
+        "SELECT isbuffer, temple, azure, venus, tmp FROM user_character WHERE use_yn=1"
     ).fetchall()
     for r in rows:
         buf = bool(r['isbuffer'])

--- a/uchsquad/scripts/generate_parties.py
+++ b/uchsquad/scripts/generate_parties.py
@@ -16,7 +16,8 @@ DB_PATH = 'your_database.db'
 TYPE_TABLE_MAP = {
     'temple': 'temple_party',
     'azure': 'azure_party',
-    'venus': 'venus_party'
+    'venus': 'venus_party',
+    'tmp': 'tmp_party'
 }
 
 def get_characters(attr):
@@ -102,7 +103,7 @@ def build_parties(char_list):
 
 def main():
     parser = argparse.ArgumentParser(
-        description='temple/azure/venus 파티를 생성해 DB에 저장하는 스크립트')
+        description='temple/azure/venus/tmp 파티를 생성해 DB에 저장하는 스크립트')
     parser.add_argument('type', choices=list(TYPE_TABLE_MAP.keys()) + ['all'],
                         help='생성할 파티 유형 또는 all')
     args = parser.parse_args()

--- a/uchsquad/scripts/party_generator.py
+++ b/uchsquad/scripts/party_generator.py
@@ -7,7 +7,7 @@ from app import get_db_connection  # Flask 앱의 DB 커넥션 사용
 def get_characters(attr: str) -> list[dict]:
     """
     use_yn=1 캐릭터 중에서
-    attr 컬럼(temple/azure/venus)이 1인 캐릭터를
+    attr 컬럼(temple/azure/venus/tmp)이 1인 캐릭터를
     adventure, chara_name, job, score, isbuffer 로 반환
     """
     conn = get_db_connection()

--- a/uchsquad/scripts/party_maker_print.py
+++ b/uchsquad/scripts/party_maker_print.py
@@ -20,22 +20,22 @@ def load_characters(db_path, role=None):
     conn = sqlite3.connect(db_path)
 
     buf_query = '''
-        SELECT adventure, chara_name, job, fame, score, isbuffer, temple, azure, venus
+        SELECT adventure, chara_name, job, fame, score, isbuffer, temple, azure, venus, tmp
         FROM user_character
         WHERE use_yn = 1
           AND isbuffer = 1
     '''
-    if role in ('temple', 'azure', 'venus'):
+    if role in ('temple', 'azure', 'venus', 'tmp'):
         buf_query += f" AND {role} = 1"
     buf_df = pd.read_sql_query(buf_query, conn)
 
     del_query = '''
-        SELECT adventure, chara_name, job, fame, score, isbuffer, temple, azure, venus
+        SELECT adventure, chara_name, job, fame, score, isbuffer, temple, azure, venus, tmp
         FROM user_character
         WHERE use_yn = 1
           AND isbuffer = 0
     '''
-    if role in ('temple', 'azure', 'venus'):
+    if role in ('temple', 'azure', 'venus', 'tmp'):
         del_query += f" AND {role} = 1"
     del_df = pd.read_sql_query(del_query, conn)
 
@@ -318,7 +318,7 @@ def wrap_create_parties_alternative(buffers, dealers):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Generate parties and insert into DB')
-    parser.add_argument('role', nargs='?', choices=['temple','azure','venus'], default=None)
+    parser.add_argument('role', nargs='?', choices=['temple','azure','venus','tmp'], default=None)
     args = parser.parse_args()
 
     base = os.path.dirname(os.path.abspath(__file__)) + '/..'

--- a/uchsquad/templates/characters.html
+++ b/uchsquad/templates/characters.html
@@ -76,14 +76,15 @@
     <button id="save-btn" type="button" class="hidden" onclick="submitFlags()">
       확인
     </button>
-	
-	{% if selected_user %}
+
+        {% if selected_user %}
           <span class="summary-note">
           여신전 {{ summary.temple[0] }} ({{ summary.temple[1] }}D, {{ summary.temple[2] }}B)
            | 애쥬어 {{ summary.azure[0] }} ({{ summary.azure[1] }}D, {{ summary.azure[2] }}B)
            | 베누스 {{ summary.venus[0] }} ({{ summary.venus[1] }}D, {{ summary.venus[2] }}B)
+           | 임시 {{ summary.tmp[0] }} ({{ summary.tmp[1] }}D, {{ summary.tmp[2] }}B)
       </span>
-	{% endif %}
+        {% endif %}
   </div>
 
   <!-- 3) 체크박스 & 순서 수정 폼 -->
@@ -105,6 +106,7 @@
           <th>여신전</th>
           <th>애쥬어</th>
           <th>베누스</th>
+          <th>임시</th>
           <th>활성화</th>
           <th class="order-col hidden">
             순서
@@ -168,6 +170,7 @@
           <td><input type="checkbox" name="temple_{{c.idx}}"    disabled {% if c.temple    %}checked{% endif %}></td>
           <td><input type="checkbox" name="azure_{{c.idx}}"     disabled {% if c.azure     %}checked{% endif %}></td>
           <td><input type="checkbox" name="venus_{{c.idx}}"     disabled {% if c.venus     %}checked{% endif %}></td>
+          <td><input type="checkbox" name="tmp_{{c.idx}}"       disabled {% if c.tmp       %}checked{% endif %}></td>
           <td><input type="checkbox" name="use_yn_{{c.idx}}"    disabled {% if c.use_yn    %}checked{% endif %}></td>
           <td class="order-col hidden">
             <button type="button" class="btn-up">↑</button>
@@ -334,11 +337,11 @@
       // 순서 수정 버튼 텍스트 및 컬럼 표시
       orderBtn.textContent = orderMode ? '수정완료' : '순서수정';
       document.querySelectorAll('.order-col')
-              .forEach(el => el.style.display = orderMode ? '' : 'none');
+              .forEach(el => el.classList.toggle('hidden', !orderMode));
 
       // 역할 수정 / 확인 버튼 표시
-      editBtn.style.display = editMode ? 'none' : '';
-      saveBtn.style.display = editMode ? '' : 'none';
+      editBtn.classList.toggle('hidden', editMode);
+      saveBtn.classList.toggle('hidden', !editMode);
 
       // 체크박스 활성화 제어
       document.querySelectorAll('#flags-form input[type="checkbox"]')

--- a/uchsquad/templates/party.html
+++ b/uchsquad/templates/party.html
@@ -22,10 +22,11 @@
     <form method="get" action="" class="inline-form">
       <label for="role-select">유형 선택:</label>
       <select id="role-select" name="role" onchange="this.form.submit()">
-	    <option value="all"  {% if selected=='all'  %}selected{% endif %}>All</option>
+            <option value="all"  {% if selected=='all'  %}selected{% endif %}>All</option>
         <option value="temple" {% if selected=='temple' %}selected{% endif %}>Temple</option>
         <option value="azure"  {% if selected=='azure'  %}selected{% endif %}>Azure</option>
         <option value="venus"  {% if selected=='venus'  %}selected{% endif %}>Venus</option>
+        <option value="tmp"    {% if selected=='tmp'    %}selected{% endif %}>임시</option>
       </select>
     </form>
     {% if selected != 'all' %}
@@ -41,14 +42,15 @@
         여신전 {{ summary.temple[0] }}명 ({{ summary.temple[1] }}D, {{ summary.temple[2] }}B)
          | 애쥬어 {{ summary.azure[0] }}명 ({{ summary.azure[1] }}D, {{ summary.azure[2] }}B)
          | 베누스 {{ summary.venus[0] }}명 ({{ summary.venus[1] }}D, {{ summary.venus[2] }}B)
+         | 임시 {{ summary.tmp[0] }}명 ({{ summary.tmp[1] }}D, {{ summary.tmp[2] }}B)
       </span>
     {% endif %}
   </div>
 
   {% if parties %}
     <div class="party-wrapper">
-      {% set prefixes = {'temple':'여','azure':'애','venus':'베','all':'전체'} %}
-      {% set cnt = namespace(tem=0, azu=0, ven=0) %}
+      {% set prefixes = {'temple':'여','azure':'애','venus':'베','tmp':'임','all':'전체'} %}
+      {% set cnt = namespace(tem=0, azu=0, ven=0, tmp=0) %}
       <!-- 왼쪽: 파티 목록 -->
       <div class="party-list">
         {% for p in parties %}
@@ -58,9 +60,12 @@
           {% elif p.type == 'azure' %}
             {% set cnt.azu = cnt.azu + 1 %}
             {% set idx = cnt.azu %}
-          {% else %}
+          {% elif p.type == 'venus' %}
             {% set cnt.ven = cnt.ven + 1 %}
             {% set idx = cnt.ven %}
+          {% elif p.type == 'tmp' %}
+            {% set cnt.tmp = cnt.tmp + 1 %}
+            {% set idx = cnt.tmp %}
           {% endif %}
 		  
           <table class="border table-auto {% if p.is_completed %}completed{% endif %}"


### PR DESCRIPTION
## Summary
- Add temporary `tmp` party type labeled '임시' selectable for party generation
- Show `tmp` counts in character and party summaries while keeping it out of the `all` view
- Extend generation scripts and database interactions to handle `tmp`
- Fix role edit button toggling so the confirm button appears correctly

## Testing
- `python -m py_compile uchsquad/blueprints/characters.py uchsquad/blueprints/party.py uchsquad/scripts/party_maker_print.py uchsquad/scripts/party_generator.py uchsquad/scripts/generate_parties.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4fe909820832189f36c408043abdb