### PR TITLE
Avoid widening buttons and selects on small screens

### DIFF
--- a/uchsquad/static/base.css
+++ b/uchsquad/static/base.css
@@ -164,16 +164,19 @@ table td input[type="checkbox"] {
   body {
     padding: 0.5rem;
   }
+  button,
+  select {
+    display: inline-block;
+    width: auto;
+    max-width: 100%;
+  }
   button {
-    display: block;
-    width: 100%;
     margin: 0.5rem 0;
     font-size: 1rem;
     padding: 0.75rem;
-    margin-right: 0;
+    margin-right: 0.25rem;
   }
   select {
-    width: 100%;
     margin-bottom: 0.5rem;
   }
   table {


### PR DESCRIPTION
## Summary
- Prevent buttons and select elements from expanding to full width on small screens
- Keep mobile layout responsive without stretching controls unnecessarily

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b52af212bc8321aba82f9b98d30b50