### PR TITLE
Improve update_score execution and gunicorn timeout

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,2 @@
+timeout = 120
+graceful_timeout = 30


### PR DESCRIPTION
## Summary
- ensure update_score uses venv Python, logs output, and times out cleanly
- add gunicorn config with extended timeout and graceful timeout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be3e99b2e88321aea867c1330a52ab