### PR TITLE
Restore console logging for update score script

### DIFF
--- a/uchsquad/blueprints/characters.py
+++ b/uchsquad/blueprints/characters.py
@@ -168,16 +168,19 @@ def update_score_for_user():
 
     is_updating = True
     try:
-        # 1) 스크립트 실행 (venv 보장, 타임아웃 및 출력 캡처)
+        # 1) 스크립트 실행 (venv 보장, 타임아웃)
         script_path = os.path.join(current_app.root_path, 'scripts', 'update_score.py')
         cp = subprocess.run(
             [sys.executable, script_path, adventure],
             check=True,
-            capture_output=True,
             text=True,
             timeout=90,
         )
-        current_app.logger.info("update_score.py stdout: %s", cp.stdout[:2000])
+        # capture_output=True 로 출력이 숨겨지는 문제를 방지하기 위해
+        # 기본 stdout/stderr 를 사용하여 콘솔에 로그를 표시한다.
+        current_app.logger.info(
+            "update_score.py finished with return code %s", cp.returncode
+        )
 
         # 2) 실행 성공 시 last_execute 테이블에 기록
         conn = get_db_connection()

--- a/uchsquad/scripts/update_score.py
+++ b/uchsquad/scripts/update_score.py
@@ -120,7 +120,6 @@ def upsert_character_history(conn, data, server):
     - 경계 시간을 넘었으면 INSERT (새 이력 생성)
     updated_at은 항상 현재 시간(now)으로 기록
     """
-    print(f"Updating score from API: {data['name']}")
     chara_name = data['name']
     fame_i     = int(data['fame'])
     server_s   = server
@@ -195,10 +194,11 @@ def fetch_and_update(tuples):
             if 'adventure' in data and 'name' in data:
                 upsert_character(conn, data, server, key)
                 upsert_character_history(conn, data, server)
+                print(f"-- {server} : {data['name']} 갱신 완료", flush=True)
             else:
-                print(f"-- {server} : {key} 갱신 실패 (응답 형식 오류)")
+                print(f"-- {server} : {key} 갱신 실패 (응답 형식 오류)", flush=True)
         except requests.RequestException as e:
-            print(f"-- {server} : {key} 갱신 실패 (에러: {e})")
+            print(f"-- {server} : {key} 갱신 실패 (에러: {e})", flush=True)
 
     conn.commit()
     conn.close()


### PR DESCRIPTION
## Summary
- Restore console output from update_score.py by removing output capture
- Log script completion status with return code
- Emit a console message after each character update

## Testing
- `python -m py_compile uchsquad/scripts/update_score.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfe885d9dc832194ef3d8717da3f1e